### PR TITLE
refactor: not abstracted contract so it can be deployed

### DIFF
--- a/contracts/utils/Governable.sol
+++ b/contracts/utils/Governable.sol
@@ -4,7 +4,6 @@ pragma solidity 0.8.4;
 
 import '../../interfaces/utils/IGovernable.sol';
 
-abstract
 contract Governable is IGovernable {
   address public override governor;
   address public override pendingGovernor;
@@ -12,6 +11,14 @@ contract Governable is IGovernable {
   constructor(address _governor) {
     require(_governor != address(0), 'governable/governor-should-not-be-zero-address');
     governor = _governor;
+  }
+
+  function setPendingGovernor(address _pendingGovernor) external virtual override onlyGovernor {
+    _setPendingGovernor(_pendingGovernor);
+  }
+
+  function acceptGovernor() external virtual override onlyPendingGovernor {
+    _acceptGovernor();
   }
 
   function _setPendingGovernor(address _pendingGovernor) internal {

--- a/contracts/utils/Machinery.sol
+++ b/contracts/utils/Machinery.sol
@@ -6,31 +6,35 @@ import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import '../../interfaces/utils/IMachinery.sol';
 import '../../interfaces/mechanics/IMechanicsRegistry.sol';
 
-abstract
 contract Machinery is IMachinery {
   using EnumerableSet for EnumerableSet.AddressSet;
 
-  IMechanicsRegistry internal MechanicsRegistry;
+  IMechanicsRegistry internal _mechanicsRegistry;
 
-  constructor(address _mechanicsRegistry) {
-    _setMechanicsRegistry(_mechanicsRegistry);
+  constructor(address __mechanicsRegistry) {
+    _setMechanicsRegistry(__mechanicsRegistry);
   }
 
   modifier onlyMechanic {
-    require(MechanicsRegistry.isMechanic(msg.sender), 'Machinery: not mechanic');
+    require(_mechanicsRegistry.isMechanic(msg.sender), 'Machinery: not mechanic');
     _;
   }
 
-  function _setMechanicsRegistry(address _mechanicsRegistry) internal {
-    MechanicsRegistry = IMechanicsRegistry(_mechanicsRegistry);
+  function setMechanicsRegistry(address __mechanicsRegistry) external virtual override {
+    _setMechanicsRegistry(__mechanicsRegistry);
+  }
+
+  function _setMechanicsRegistry(address __mechanicsRegistry) internal {
+    _mechanicsRegistry = IMechanicsRegistry(__mechanicsRegistry);
   }
 
   // View helpers
   function mechanicsRegistry() external view override returns (address _mechanicRegistry) {
-    return address(MechanicsRegistry);
+    return address(_mechanicsRegistry);
   }
+
   function isMechanic(address _mechanic) public view override returns (bool _isMechanic) {
-    return MechanicsRegistry.isMechanic(_mechanic);
+    return _mechanicsRegistry.isMechanic(_mechanic);
   }
 
 }


### PR DESCRIPTION
### WHY ?
Why would a human being used a non-abstracted contract as a default ? Well ... If I want to use this bytecode, I need the contracts to not be abstract so they can be deployed.

We can do either this, or have a "ready" or something like that folder, where we have our contracts on their "final-non-abstract" form. 

Either way, I need a way of having bytecode of "final deployable contracts" from this repo :pray: 